### PR TITLE
Ignore ParameterValue in Update if UsePreviousValue === true

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,15 @@ function updateStack(cfn, args, cb) {
       const ret = {
         ParameterKey: parameter.ParameterKey
       };
-      if (parameter.ParameterValue !== undefined) {
+      if (parameter.ParameterValue !== undefined && parameter.UsePreviousValue === true) {
+        console.warn([
+          'Parameter',
+          parameter.ParameterKey,
+          'contains both ParameterValue and UsePreviousValue == true.',
+          ' ParameterValue will be ignored.'
+        ].join(' '));
+      }
+      if (parameter.ParameterValue !== undefined && parameter.UsePreviousValue !== true) {
         ret.ParameterValue = parameter.ParameterValue;
       }
       if (parameter.UsePreviousValue !== undefined) {


### PR DESCRIPTION
Currently, if you define `UsePreviousValue` for a parameter, the update operation will fail with an error like: `Invalid input for parameter key <ParameterKey>. Cannot specify usePreviousValue as true and non empty value for a parameter`

This PR will print a warning if this happens and will ignore ParameterValue during the update if usePreviousValue == true.