### PR TITLE
Splitting on the first '=' to allow '=' symbols in parameter values

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -26,7 +26,7 @@ function parseParameter(val) {
 // ParameterKey=string,ParameterValue=string,UsePreviousValue=boolean
 exports.parameter = (val) => {
   const ret = {};
-  const pairs = parseParameter(val).map((pair) => pair.split('='));
+  const pairs = parseParameter(val).map((pair) => pair.split(/=(.+)/));
   pairs.forEach((pair) => {
     if (pair[0] === 'ParameterKey') {
       ret.ParameterKey = pair[1];
@@ -51,7 +51,7 @@ exports.string = (val) => {
 // Key=string,Value=string
 exports.tag = (val) => {
   const ret = {};
-  const pairs = val.split(',').map((pair) => pair.split('='));
+  const pairs = val.split(',').map((pair) => pair.split(/=(.+)/));
   pairs.forEach((pair) => {
     if (pair[0] === 'Key') {
       ret.key = pair[1];

--- a/test/map.js
+++ b/test/map.js
@@ -18,6 +18,13 @@ describe('map', function() {
         UsePreviousValue: false
       });
     });
+    it('ParameterKey=key,ParameterValue="x=y",UsePreviousValue=false', function() {
+      assert.deepEqual(map.parameter('ParameterKey=key,ParameterValue="x=y",UsePreviousValue=false'), {
+        ParameterKey: 'key',
+        ParameterValue: 'x=y',
+        UsePreviousValue: false
+      });
+    });
     it('ParameterKey=key,ParameterValue=value', function() {
       assert.deepEqual(map.parameter('ParameterKey=key,ParameterValue=value'), {
         ParameterKey: 'key',
@@ -28,6 +35,12 @@ describe('map', function() {
       assert.throws(() => {
         map.parameter('ParameterKey=key,Unexpected=value');
       }, Error);
+    });
+    it('ParameterKey=key,ParameterValue="x=y"', function() {
+      assert.deepEqual(map.parameter('ParameterKey=key,ParameterValue="x=y"'), {
+        ParameterKey: 'key',
+        ParameterValue: 'x=y'
+      });
     });
     it('ParameterKey=key,ParameterValue="value1,value2",UsePreviousValue=false', function() {
       assert.deepEqual(map.parameter('ParameterKey=key,ParameterValue="value1,value2",UsePreviousValue=false'), {


### PR DESCRIPTION
I've been having problems with my parameters with '=' symbols inside. This splits on the first '=' symbol instead of all symbols, allowing us to use the '=' in our paramters.